### PR TITLE
Update special case json_decode for PHP 8

### DIFF
--- a/lib/special_cases.php
+++ b/lib/special_cases.php
@@ -18,19 +18,19 @@ use Safe\Exceptions\PcreException;
 /**
  * Wrapper for json_decode that throws when an error occurs.
  *
- * @param string $json    JSON data to parse
- * @param bool $assoc     When true, returned objects will be converted
- *                        into associative arrays.
- * @param int $depth   User specified recursion depth.
- * @param int $options Bitmask of JSON decode options.
+ * @param string    $json        JSON data to parse
+ * @param bool|null $associative When true, returned objects will be converted
+ *                               into associative arrays.
+ * @param int       $depth       User specified recursion depth.
+ * @param int       $flags       Bitmask of JSON decode options.
  *
  * @return mixed
  * @throws JsonException if the JSON cannot be decoded.
  * @link http://www.php.net/manual/en/function.json-decode.php
  */
-function json_decode(string $json, bool $assoc = false, int $depth = 512, int $options = 0)
+function json_decode(string $json, bool|null $associative = null, int $depth = 512, int $flags = 0): mixed
 {
-    $data = \json_decode($json, $assoc, $depth, $options);
+    $data = \json_decode($json, $associative, $depth, $flags);
     if (JSON_ERROR_NONE !== json_last_error()) {
         throw JsonException::createFromPhpError();
     }


### PR DESCRIPTION
Just a simple patch to update the special `json_decode` case for PHP 8.

It fixes named arguments problems due to a discrepancy between code and docs.