### PR TITLE
Add PHPDoc return type to DateTimeImmutable::createFromFormat()

### DIFF
--- a/lib/DateTimeImmutable.php
+++ b/lib/DateTimeImmutable.php
@@ -53,6 +53,7 @@ class DateTimeImmutable extends \DateTimeImmutable
      * @param string $format
      * @param string $time
      * @param DateTimeZone|null $timezone
+     * @return DateTimeImmutable
      * @throws DatetimeException
      */
     public static function createFromFormat($format, $time, $timezone = null)


### PR DESCRIPTION
When using PHPStan to analyze a project using `Safe\DateTimeImmutable::createFromFormat()`,
the return type from the built-in `DateTimeImmutable` class is assumed.

This change adds a return type PHPDoc comment to help PHPStan understand.